### PR TITLE
Add conda cl to test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
 - travis_retry pip install -e .
 
 script:
-# - flake8 --ignore N802,N806,E501 `find . -name \*.py | grep -v setup.py | grep -v version.py | grep -v __init__.py | grep -v /doc/`
-# - pytest --pyargs toymir --cov-report term-missing --cov=toymir
+#  - flake8 --ignore N802,N806,E501 `find . -name \*.py | grep -v setup.py | grep -v version.py | grep -v __init__.py | grep -v /doc/`
+#  - pytest --pyargs toymir --cov-report term-missing --cov=toymir
   - pytest
 
 # Hey, this block (and the above arguments to pytest )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ scipy
 matplotlib
 jupyter
 sphinx
+numpydoc
 flake8
 pytest

--- a/scripts/test_tutorial_install.sh
+++ b/scripts/test_tutorial_install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Add conda magic to this environment
+. ~/anaconda3/etc/profile.d/conda.sh
+
 echo "Checking git and conda"
 git --version
 if [ $? -ne 0 ]

--- a/toymir/freq.py
+++ b/toymir/freq.py
@@ -41,7 +41,7 @@ def hz_to_midi(frequencies):
     # less_than_zero = (np.asanyarray(frequencies) <= 0).any()
 
     # if less_than_zero:
-    #     raise ValueError('Cannot convert a frequency of zero or less to a period.')
+    #     raise ValueError('Cannot convert a hz of zero or less to a period.')
 
     # return 12 * (np.log2(np.asanyarray(frequencies)) - np.log2(440.0)) + 69
 
@@ -74,6 +74,6 @@ def hz_to_period(frequencies):
     less_than_zero = (np.asanyarray(frequencies) <= 0).any()
 
     if less_than_zero:
-        raise ValueError('Cannot convert a frequency of zero or less to a period.')
+        raise ValueError('Cannot convert a hz of zero or less to a period.')
 
     return 1 / np.asanyarray(frequencies)

--- a/toymir/tests/test_toymir.py
+++ b/toymir/tests/test_toymir.py
@@ -28,7 +28,7 @@ def test_midi_to_hz_array():
 #    assert np.allclose(toymir.hz_to_midi([220.0, 440.0, 880.0]), expected)
 
 
-# Hello!  You could add the missing test for test_hz_to_midi here, in the middle of Part 5!
+# Hello!  You could add the missing test for test_hz_to_midi here!
 
 
 def test_hz_to_period_float():


### PR DESCRIPTION
@bmcfee, this is the final (:fire) update to the code, matching the updates in #30.

- Tweak the comments in `.travis.yaml` to help people avoid yaml indentation errors.
- Add numpydoc to `requirements.txt`, as sphinx needs it.
- Fix tiny flake8 errors in code and tessts so that we only get the desired seaborn error.

- And, the one I want your opinion on, I updated the test script to run the conda setup script - this dynamically creates the `conda` command, and appears to be new in conda 4.5.  Does this seem safe / make sense?  Otherwise, the script can't find conda even though the user can.