### PR TITLE
Add seaborn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinx
 numpydoc
 flake8
 pytest
+seaborn 


### PR DESCRIPTION
An error appeared saying " ModuleNotFoundError: No module named 'seaborn' " when running tests. Added "seaborn" to requirements.txt. 